### PR TITLE
Deere rework styling

### DIFF
--- a/res/skins/Deere/deck_controls_row.xml
+++ b/res/skins/Deere/deck_controls_row.xml
@@ -15,8 +15,11 @@
         <Layout>horizontal</Layout>
         <Children>
           <Template src="skin:transport.xml"/>
+          <!-- Expanding spacers in between control contexts -->
+          <WidgetGroup><Size>-1me,1min</Size><Children/></WidgetGroup>
           <Template src="skin:beatloop.xml"/>
           <Template src="skin:loop.xml"/>
+          <WidgetGroup><Size>-1me,1min</Size><Children/></WidgetGroup>
           <Template src="skin:hotcue.xml"/>
         </Children>
         <Connection>
@@ -103,6 +106,11 @@
             <SetVariable name="right_connection_control"><Variable name="group"/>,cue_gotoandstop</SetVariable>
             <SetVariable name="display_connection_control"><Variable name="group"/>,cue_indicator</SetVariable>
           </Template>
+
+          <!-- Workaround for layout spacing
+          <Template src="skin:spacer_hx.xml">
+            <SetVariable name="width">2</SetVariable>
+          </Template> -->
 
           <Template src="skin:left_right_display_2state_button.xml">
             <SetVariable name="TooltipId">play_cue_set</SetVariable>

--- a/res/skins/Deere/deck_controls_row.xml
+++ b/res/skins/Deere/deck_controls_row.xml
@@ -52,7 +52,12 @@
                 <SetVariable name="state_1_pressed">icon/ic_quantize_48px.svg</SetVariable>
                 <SetVariable name="state_1_unpressed">icon/ic_quantize_48px.svg</SetVariable>
                 <SetVariable name="left_connection_control"><Variable name="group"/>,quantize</SetVariable>
-              </Template>
+                </Template>
+
+                <!-- Workaround for layout spacing -->
+                <Template src="skin:spacer_hx.xml">
+                  <SetVariable name="width">2</SetVariable>
+                </Template>
 
               <Template src="skin:left_2state_button.xml">
                 <SetVariable name="TooltipId">keylock</SetVariable>
@@ -67,6 +72,11 @@
                 <SetVariable name="state_1_pressed">icon/ic_key_48px.svg</SetVariable>
                 <SetVariable name="state_1_unpressed">icon/ic_key_48px.svg</SetVariable>
                 <SetVariable name="left_connection_control"><Variable name="group"/>,keylock</SetVariable>
+              </Template>
+
+              <!-- Workaround for layout spacing -->
+              <Template src="skin:spacer_hx.xml">
+                <SetVariable name="width">2</SetVariable>
               </Template>
 
               <Template src="skin:left_2state_button.xml">
@@ -107,10 +117,10 @@
             <SetVariable name="display_connection_control"><Variable name="group"/>,cue_indicator</SetVariable>
           </Template>
 
-          <!-- Workaround for layout spacing
+          <!-- Workaround for layout spacing -->
           <Template src="skin:spacer_hx.xml">
             <SetVariable name="width">2</SetVariable>
-          </Template> -->
+          </Template>
 
           <Template src="skin:left_right_display_2state_button.xml">
             <SetVariable name="TooltipId">play_cue_set</SetVariable>

--- a/res/skins/Deere/deck_inner_column.xml
+++ b/res/skins/Deere/deck_inner_column.xml
@@ -121,6 +121,11 @@
               <SetVariable name="display_connection_control"><Variable name="group"/>,cue_indicator</SetVariable>
             </Template>
 
+            <!-- Workaround for layout spacing -->
+            <Template src="skin:spacer_vx.xml">
+              <SetVariable name="height">2</SetVariable>
+            </Template>
+
             <Template src="skin:left_right_display_2state_button.xml">
               <SetVariable name="TooltipId">play_cue_set</SetVariable>
               <SetVariable name="ObjectName">PlayToggle</SetVariable>

--- a/res/skins/Deere/deck_mixer_controls_col2.xml
+++ b/res/skins/Deere/deck_mixer_controls_col2.xml
@@ -20,7 +20,6 @@
           <Template src="skin:left_2state_button.xml">
             <SetVariable name="TooltipId">pfl</SetVariable>
             <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
-            <!-- make Pfl button bigger because it's important and space is occupied anyway -->
             <SetVariable name="MinimumSize">30,30</SetVariable>
             <SetVariable name="MaximumSize">30,30</SetVariable>
             <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>

--- a/res/skins/Deere/deck_mixer_controls_col2.xml
+++ b/res/skins/Deere/deck_mixer_controls_col2.xml
@@ -20,8 +20,9 @@
           <Template src="skin:left_2state_button.xml">
             <SetVariable name="TooltipId">pfl</SetVariable>
             <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
-            <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-            <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+            <!-- make Pfl button bigger because it's important and space is occupied anyway -->
+            <SetVariable name="MinimumSize">30,30</SetVariable>
+            <SetVariable name="MaximumSize">30,30</SetVariable>
             <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
             <SetVariable name="state_0_text"></SetVariable>
             <SetVariable name="state_0_pressed">icon/ic_headphones_48px.svg</SetVariable>
@@ -49,8 +50,9 @@
           <Template src="skin:left_2state_button.xml">
             <SetVariable name="TooltipId">pfl</SetVariable>
             <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
-            <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-            <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+            <!-- make Pfl button bigger because it's important and space is occupied anyway -->
+            <SetVariable name="MinimumSize">25,25</SetVariable>
+            <SetVariable name="MaximumSize">25,25</SetVariable>
             <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
             <SetVariable name="state_0_text"></SetVariable>
             <SetVariable name="state_0_pressed">icon/ic_headphones_48px.svg</SetVariable>

--- a/res/skins/Deere/equalizer_rack_parameter_right.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_right.xml
@@ -19,6 +19,7 @@
     <Children>
 
       <SizeAwareStack>
+        <Size>40f,-1me</Size>
         <Children>
 
           <WidgetGroup>

--- a/res/skins/Deere/hotcue.xml
+++ b/res/skins/Deere/hotcue.xml
@@ -10,10 +10,11 @@
   <WidgetGroup>
     <ObjectName>HotcueGrid</ObjectName>
     <Layout>vertical</Layout>
-    <SizePolicy>max,max</SizePolicy>
+    <SizePolicy>min,min</SizePolicy>
     <Children>
       <WidgetGroup>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
@@ -24,8 +25,13 @@
         </Children>
       </WidgetGroup>
 
+      <!-- Workaround. Remove when https://bugs.launchpad.net/mixxx/+bug/1578111
+          is fixed -->
+      <WidgetGroup><Size>1min,2f</Size><Children/></WidgetGroup>
+
       <WidgetGroup>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:hotcue_button.xml">
             <SetVariable name="hotcue">3</SetVariable>
@@ -49,11 +55,11 @@
   <WidgetGroup>
     <ObjectName>HotcueGridExtended</ObjectName>
     <Layout>vertical</Layout>
-    <SizePolicy>max,max</SizePolicy>
+    <SizePolicy>min,min</SizePolicy>
     <Children>
       <WidgetGroup>
-        <ObjectName>HotcueGridExtendedRow1</ObjectName>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
@@ -71,8 +77,8 @@
       </WidgetGroup>
 
       <WidgetGroup>
-        <ObjectName>HotcueGridExtendedRow2</ObjectName>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:hotcue_button.xml">
             <SetVariable name="hotcue">5</SetVariable>

--- a/res/skins/Deere/main_decks.xml
+++ b/res/skins/Deere/main_decks.xml
@@ -111,7 +111,7 @@
     </Connection>
   </WidgetGroup>
 
-    <WidgetGroup>
+  <WidgetGroup>
     <ObjectName>MainDeckContainer</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>me,me</SizePolicy>

--- a/res/skins/Deere/sampler_bank_controls.xml
+++ b/res/skins/Deere/sampler_bank_controls.xml
@@ -11,7 +11,7 @@
   <WidgetGroup>
     <ObjectName>SamplerBankContainer</ObjectName>
     <Layout>horizontal</Layout>
-    <SizePolicy>min,f</SizePolicy>
+    <SizePolicy>min,min</SizePolicy>
     <Children>
       <Label>
         <ObjectName>SamplerBankLabel</ObjectName>
@@ -102,7 +102,9 @@
       </Label>
 
       <WidgetGroup>
+        <ObjectName>SamplerBankGrid</ObjectName>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:left_2state_button.xml">
             <!-- TODO(jus): Add missing string to src/skin/tooltips.cpp -->
@@ -138,7 +140,9 @@
       </WidgetGroup>
 
       <WidgetGroup>
+        <ObjectName>SamplerBankGrid</ObjectName>
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:left_2state_button.xml">
             <!-- TODO(jus): Add missing string to src/skin/tooltips.cpp -->
@@ -176,7 +180,9 @@
       <Template src="skin:spacer_v.xml"/>
 
       <WidgetGroup>
+        <ObjectName>SamplerBankGrid</ObjectName>
         <Layout>vertical</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:left_1state_button.xml">
             <!-- TODO(jus): Add missing string to src/skin/tooltips.cpp -->

--- a/res/skins/Deere/spacer_hx.xml
+++ b/res/skins/Deere/spacer_hx.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE template>
+<!--
+Description: Spacer.
+-->
+<Template>
+  <WidgetGroup>
+    <ObjectName>Spacer</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>min,min</SizePolicy>
+    <Size><Variable name="width"/></Size>
+    <MinimumSize><Variable name="width"/></MinimumSize>
+    <MaximumSize><Variable name="width"/></MaximumSize>
+    <Children>
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -623,13 +623,15 @@ WWidget, QLabel {
   qproperty-layoutSpacing: 5;
 }
 
+#MinimalControlsContainer {
+  qproperty-layoutSpacing: 2;}
+
 #HotcueGrid, #HotcueGridExtended {
   background-color: #333333;
   padding: 1px;
   qproperty-layoutSpacing: 2;
 }
 #HotcueGridExtendedRow1, #HotcueGridExtendedRow1 {
-  qproperty-layoutSpacing: 2;
 }
 
 #HotcueGrid WWidgetGroup, #HotcueGridExtended WWidgetGroup {
@@ -1071,6 +1073,13 @@ WStarRating {
 #SamplerBankContainer {
   padding: 4px;
   qproperty-layoutSpacing: 2;
+}
+
+#SamplerBankGrid {
+  qproperty-layoutSpacing: 2;
+}
+
+#SamplerBankToggle {
 }
 
 #SampleDecksExpanded, #SampleDecksCollapsed {

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -631,8 +631,6 @@ WWidget, QLabel {
   padding: 1px;
   qproperty-layoutSpacing: 2;
 }
-#HotcueGridExtendedRow1, #HotcueGridExtendedRow1 {
-}
 
 #HotcueGrid WWidgetGroup, #HotcueGridExtended WWidgetGroup {
   qproperty-layoutSpacing: 2;
@@ -1077,9 +1075,6 @@ WStarRating {
 
 #SamplerBankGrid {
   qproperty-layoutSpacing: 2;
-}
-
-#SamplerBankToggle {
 }
 
 #SampleDecksExpanded, #SampleDecksCollapsed {

--- a/res/skins/Deere/vinylcontrol.xml
+++ b/res/skins/Deere/vinylcontrol.xml
@@ -4,7 +4,7 @@
     <WidgetGroup>
     <ObjectName>VinylControlsContainer</ObjectName>
     <Layout>vertical</Layout>
-    <SizePolicy>max,max</SizePolicy>
+    <SizePolicy>min,min</SizePolicy>
     <Connection>
       <ConfigKey persist="true">[VinylControl],show_vinylcontrol</ConfigKey>
       <BindProperty>visible</BindProperty>


### PR DESCRIPTION
Did some polish:
- button grids' layout-spacing now respected
  >set SizePolicy to min,min, though this trick doesn't seem to work everywhere, i.e. in vinylcontrols it doesn't
- button groups in deck_controls_row pushed apart to be distinguish better fro each other
- fixed EQ kill button appearance on right channel
  >when coming from 4deck/stacked_wave they were cut off a the right
- bigger Pfl buttons: they are important and space is occupied anyway due to greater height/width of surrounding knobs
  > did this manually, should there be another Variable in skin.xml for that?
- spacer_hx.xml added where horizontal dimension can be defined
- deck buttons: 2px spacing minimal view
  > this is working around https://bugs.launchpad.net/mixxx/+bug/1578111 which is 8 months old