### PR TITLE
fix highlighted xfader orientation buttons

### DIFF
--- a/res/skins/Deere/auxiliary.xml
+++ b/res/skins/Deere/auxiliary.xml
@@ -64,7 +64,9 @@
                     <SetVariable name="left_connection_control"><Variable name="group"/>,pfl</SetVariable>
                   </Template>
 
-                  <Template src="skin:crossfader_orientation_button.xml" />
+                  <Template src="skin:crossfader_orientation_button.xml">
+                    <SetVariable name="Unit">Aux</SetVariable>
+                  </Template>
 
                 </Children>
               </WidgetGroup>

--- a/res/skins/Deere/crossfader_orientation_button.xml
+++ b/res/skins/Deere/crossfader_orientation_button.xml
@@ -1,7 +1,7 @@
 <Template>
   <Template src="skin:left_3state_button.xml">
     <SetVariable name="TooltipId">orientation</SetVariable>
-    <SetVariable name="ObjectName">OrientationButton</SetVariable>
+    <SetVariable name="ObjectName">OrientationButton<Variable name="Unit"/></SetVariable>
     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
     <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
     <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>

--- a/res/skins/Deere/effect_rack.xml
+++ b/res/skins/Deere/effect_rack.xml
@@ -37,6 +37,11 @@ Container for all the effect units
                     <SetVariable name="EffectUnit">1</SetVariable>
                   </Template>
 
+                  <Template src="skin:spacer_hx.xml">
+                    <SetVariable name="width">4</SetVariable>
+                    <SetVariable name="color">22</SetVariable>
+                  </Template>
+
                   <Template src="skin:effect_unit.xml">
                     <SetVariable name="EffectRack">1</SetVariable>
                     <SetVariable name="EffectUnit">2</SetVariable>
@@ -54,6 +59,11 @@ Container for all the effect units
                   <Template src="skin:effect_unit.xml">
                     <SetVariable name="EffectRack">1</SetVariable>
                     <SetVariable name="EffectUnit">3</SetVariable>
+                  </Template>
+
+                  <Template src="skin:spacer_hx.xml">
+                    <SetVariable name="width">4</SetVariable>
+                    <SetVariable name="color">22</SetVariable>
                   </Template>
 
                   <Template src="skin:effect_unit.xml">

--- a/res/skins/Deere/mixer_controls_col2.xml
+++ b/res/skins/Deere/mixer_controls_col2.xml
@@ -133,7 +133,9 @@
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:crossfader_orientation_button.xml" />
+          <Template src="skin:crossfader_orientation_button.xml">
+            <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
+          </Template>
         </Children>
         <Connection>
           <ConfigKey>[Master],show_4decks</ConfigKey>

--- a/res/skins/Deere/mixer_controls_condensed_left.xml
+++ b/res/skins/Deere/mixer_controls_condensed_left.xml
@@ -133,7 +133,7 @@
             <Children>
 
               <Template src="skin:spacer_vx.xml">
-                <SetVariable name="width">2</SetVariable>
+                <SetVariable name="height">2</SetVariable>
               </Template>
 
               <Template src="skin:crossfader_orientation_button.xml">

--- a/res/skins/Deere/mixer_controls_condensed_left.xml
+++ b/res/skins/Deere/mixer_controls_condensed_left.xml
@@ -129,25 +129,17 @@
           <WidgetGroup>
             <ObjectName>CondensedButtonContainerLeft</ObjectName>
             <Size>-1me,25f</Size>
-            <Layout>horizontal</Layout>
+            <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:left_3state_button.xml">
-                <SetVariable name="TooltipId">orientation</SetVariable>
-                <SetVariable name="ObjectName">OrientationButton</SetVariable>
-                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                <SetVariable name="state_0_text"></SetVariable>
-                <SetVariable name="state_0_pressed">icon/ic_orientation_left_48px.svg</SetVariable>
-                <SetVariable name="state_0_unpressed">icon/ic_orientation_left_48px.svg</SetVariable>
-                <SetVariable name="state_1_text"></SetVariable>
-                <SetVariable name="state_1_pressed">icon/ic_orientation_48px.svg</SetVariable>
-                <SetVariable name="state_1_unpressed">icon/ic_orientation_48px.svg</SetVariable>
-                <SetVariable name="state_2_text"></SetVariable>
-                <SetVariable name="state_2_pressed">icon/ic_orientation_right_48px.svg</SetVariable>
-                <SetVariable name="state_2_unpressed">icon/ic_orientation_right_48px.svg</SetVariable>
-                <SetVariable name="left_connection_control"><Variable name="group"/>,orientation</SetVariable>
+
+              <Template src="skin:spacer_vx.xml">
+                <SetVariable name="width">2</SetVariable>
               </Template>
+
+              <Template src="skin:crossfader_orientation_button.xml">
+                <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
+              </Template>
+
             </Children>
           </WidgetGroup>
         </Children>

--- a/res/skins/Deere/mixer_controls_condensed_right.xml
+++ b/res/skins/Deere/mixer_controls_condensed_right.xml
@@ -134,7 +134,7 @@
             <Children>
 
               <Template src="skin:spacer_vx.xml">
-                <SetVariable name="width">2</SetVariable>
+                <SetVariable name="height">2</SetVariable>
               </Template>
 
               <Template src="skin:crossfader_orientation_button.xml">

--- a/res/skins/Deere/mixer_controls_condensed_right.xml
+++ b/res/skins/Deere/mixer_controls_condensed_right.xml
@@ -130,25 +130,17 @@
           <WidgetGroup>
             <ObjectName>CondensedButtonContainerRight</ObjectName>
             <Size>-1me,25f</Size>
-            <Layout>horizontal</Layout>
+            <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:left_3state_button.xml">
-                <SetVariable name="TooltipId">orientation</SetVariable>
-                <SetVariable name="ObjectName">OrientationButton</SetVariable>
-                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                <SetVariable name="state_0_text"></SetVariable>
-                <SetVariable name="state_0_pressed">icon/ic_orientation_left_48px.svg</SetVariable>
-                <SetVariable name="state_0_unpressed">icon/ic_orientation_left_48px.svg</SetVariable>
-                <SetVariable name="state_1_text"></SetVariable>
-                <SetVariable name="state_1_pressed">icon/ic_orientation_48px.svg</SetVariable>
-                <SetVariable name="state_1_unpressed">icon/ic_orientation_48px.svg</SetVariable>
-                <SetVariable name="state_2_text"></SetVariable>
-                <SetVariable name="state_2_pressed">icon/ic_orientation_right_48px.svg</SetVariable>
-                <SetVariable name="state_2_unpressed">icon/ic_orientation_right_48px.svg</SetVariable>
-                <SetVariable name="left_connection_control"><Variable name="group"/>,orientation</SetVariable>
+
+              <Template src="skin:spacer_vx.xml">
+                <SetVariable name="width">2</SetVariable>
               </Template>
+
+              <Template src="skin:crossfader_orientation_button.xml">
+                <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
+              </Template>
+
             </Children>
           </WidgetGroup>
 

--- a/res/skins/Deere/sampler_controls_row.xml
+++ b/res/skins/Deere/sampler_controls_row.xml
@@ -102,22 +102,8 @@
             <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_tempo</SetVariable>
           </Template>
 
-          <Template src="skin:left_3state_button.xml">
-            <SetVariable name="TooltipId">orientation</SetVariable>
-            <SetVariable name="ObjectName">OrientationButton</SetVariable>
-            <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-            <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-            <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-            <SetVariable name="state_0_text"></SetVariable>
-            <SetVariable name="state_0_pressed">icon/ic_orientation_left_48px.svg</SetVariable>
-            <SetVariable name="state_0_unpressed">icon/ic_orientation_left_48px.svg</SetVariable>
-            <SetVariable name="state_1_text"></SetVariable>
-            <SetVariable name="state_1_pressed">icon/ic_orientation_48px.svg</SetVariable>
-            <SetVariable name="state_1_unpressed">icon/ic_orientation_48px.svg</SetVariable>
-            <SetVariable name="state_2_text"></SetVariable>
-            <SetVariable name="state_2_pressed">icon/ic_orientation_right_48px.svg</SetVariable>
-            <SetVariable name="state_2_unpressed">icon/ic_orientation_right_48px.svg</SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,orientation</SetVariable>
+          <Template src="skin:crossfader_orientation_button.xml">
+            <SetVariable name="Unit">Sampler</SetVariable>
           </Template>
 
           <Template src="skin:left_1state_button.xml">

--- a/res/skins/Deere/spacer_hx.xml
+++ b/res/skins/Deere/spacer_hx.xml
@@ -4,12 +4,12 @@ Description: Spacer.
 -->
 <Template>
   <WidgetGroup>
-    <ObjectName>Spacer</ObjectName>
+    <ObjectName>Spacer<Variable name="color"/></ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Size><Variable name="width"/></Size>
-    <MinimumSize><Variable name="width"/></MinimumSize>
-    <MaximumSize><Variable name="width"/></MaximumSize>
+    <MinimumSize><Variable name="width"/>,-1</MinimumSize>
+    <MaximumSize><Variable name="width"/>,-1</MaximumSize>
     <Children>
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1352,11 +1352,20 @@ WPushButton[value="2"]:hover {
 }
 
 /* Special case "orientation" controls
-  1 -- center / default (off)
-  2 -- right
   0 -- left
+  1 -- center / off
+  2 -- right
 */
-#OrientationButton[value="1"] {
+/* Default xfader positions:
+  left decks = left xfader
+  right decks = right xfader
+  auxiliary = center */
+#OrientationButtonDeck1[value="0"],
+#OrientationButtonDeck3[value="0"],
+#OrientationButtonDeck2[value="2"],
+#OrientationButtonDeck4[value="2"],
+#OrientationButtonAux[value="1"],
+#OrientationButtonSampler[value="1"] {
     color: #D2D2D2;
     background-color: #4B4B4B;
     border: 1px solid #4B4B4B;
@@ -1364,31 +1373,49 @@ WPushButton[value="2"]:hover {
     outline: none;
 }
 
-#OrientationButton:hover {
+#OrientationButtonDeck1[value="0"]:hover,
+#OrientationButtonDeck3[value="0"]:hover,
+#OrientationButtonDeck2[value="2"]:hover,
+#OrientationButtonDeck4[value="2"]:hover,
+#OrientationButtonAux[value="1"]:hover,
+#OrientationButtonSampler[value="1"]:hover {
     color: #D2D2D2;
     background-color: #5F5F5F;
     border: 0px solid #5F5F5F;
 }
 
-#OrientationButton[value="2"] {
+/* Highlight xfader special positions != default */
+#OrientationButtonDeck1[value="1"],
+#OrientationButtonDeck1[value="2"],
+#OrientationButtonDeck3[value="1"],
+#OrientationButtonDeck3[value="2"],
+#OrientationButtonDeck2[value="0"],
+#OrientationButtonDeck2[value="1"],
+#OrientationButtonDeck4[value="0"],
+#OrientationButtonDeck4[value="1"],
+#OrientationButtonAux[value="0"],
+#OrientationButtonAux[value="2"],
+#OrientationButtonSampler[value="0"],
+#OrientationButtonSampler[value="2"] {
     color: #FDFDFD;
     background-color: #006596;
     border: 0px solid #006596;
+    border-radius: 2px;
+    outline: none;
 }
 
-#OrientationButton[value="2"]:hover {
-    color: #FDFDFD;
-    background-color: #0080BE;
-    border: 0px solid #0080BE;
-}
-
-#OrientationButton[value="0"] {
-    color: #FDFDFD;
-    background-color: #006596;
-    border: 0px solid #006596;
-}
-
-#OrientationButton[value="0"]:hover {
+#OrientationButtonDeck1[value="1"]:hover,
+#OrientationButtonDeck1[value="2"]:hover,
+#OrientationButtonDeck3[value="1"]:hover,
+#OrientationButtonDeck3[value="2"]:hover,
+#OrientationButtonDeck2[value="0"]:hover,
+#OrientationButtonDeck2[value="1"]:hover,
+#OrientationButtonDeck4[value="0"]:hover,
+#OrientationButtonDeck4[value="1"]:hover,
+#OrientationButtonAux[value="0"]:hover,
+#OrientationButtonAux[value="2"]:hover,
+#OrientationButtonSampler[value="0"]:hover,
+#OrientationButtonSampler[value="2"]:hover {
     color: #FDFDFD;
     background-color: #0080BE;
     border: 0px solid #0080BE;

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -115,6 +115,10 @@
   border-width: 1px 0px;
 }
 
+#Spacer22 {
+  background-color: #222222;
+}
+
 #SamplerRow1,
 #SamplerRow2,
 #SamplerRow3,


### PR DESCRIPTION
- make the highlighted position of xfader buttons depend on deck side.
- use xFader button template also for samplers and aux.
- in condensed mixer, I added a 2px v-spacer in between Vol fader and xFader buttons
- 4px h-spacer in between FX units