### PR TITLE
Shade style fixes 

### DIFF
--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -93,6 +93,7 @@ WEffectSelector::down-arrow {
   background-color: #99a0a4;
   border: 1px solid #191919;
   margin-bottom: 2px;
+  margin-left: 10px;
 }
 
 WEffectSelector QAbstractItemView {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -19,8 +19,6 @@
   padding: 5px 0px;
 }
 
-
-
 WBeatSpinBox,
 /* For some mysterious reason #DlgAutoDJ QSpinBox
 wouldn't style the respective spinbox in Shade (anymore),
@@ -62,7 +60,7 @@ WBeatSpinBox::down-button,
   image: url(skin:/btn/btn_spin_down.png) no-repeat;
 }
 
-
+#fadeModeCombobox,
 WEffectSelector {
   color: #060613;
   background-color: #aab2b7;
@@ -74,17 +72,27 @@ WEffectSelector {
   font: 13px;
 }
 
+#fadeModeCombobox::drop-down,
 WEffectSelector::drop-down {
   /* This causes the Qt theme's widget style to magically not apply. Go figure. */
   border: 0;
 }
 
+#fadeModeCombobox::down-arrow,
 WEffectSelector::down-arrow {
   height: 20px;
   border-style: solid;
   border-color: #060613;
   border-width: 0px 0px 0px 1px;
   image: url(skin:/btn/btn_spin_down.png) no-repeat;
+}
+
+
+#fadeModeCombobox {
+  height: 20px;
+  background-color: #99a0a4;
+  border: 1px solid #191919;
+  margin-bottom: 2px;
 }
 
 WEffectSelector QAbstractItemView {
@@ -396,7 +404,11 @@ The general rule when it comes to stylesheets is always to remember that if you 
 /* transition time in Auto DJ tab*/
 QSpinBox:editable,
 /* or addressed directly */
-#spinBoxTransition {}
+#spinBoxTransition {
+  height: 20px;
+  border: 1px solid #191919;
+  background-color: #99a0a4;
+}
 
 /* Cover Art*/
 WCoverArt {

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>913</width>
+    <width>885</width>
     <height>399</height>
    </rect>
   </property>
@@ -48,6 +48,12 @@
      </property>
      <item>
       <widget class="QPushButton" name="pushButtonAutoDJ">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string>Turn Auto DJ on or off.</string>
        </property>
@@ -58,6 +64,80 @@
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonFadeNow">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Trigger the transition to the next track.</string>
+       </property>
+       <property name="text">
+        <string>Fade Now</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonSkipNext">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Skip the next track in the Auto DJ queue.</string>
+       </property>
+       <property name="text">
+        <string>Skip Track</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonShuffle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Shuffle the content of the Auto DJ queue.</string>
+       </property>
+       <property name="text">
+        <string>Shuffle</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonAddRandom">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Adds a random track from track sources (crates) to the Auto DJ queue.
+If no track sources are configured, the track is added from the library instead.</string>
+       </property>
+       <property name="text">
+        <string>Add Random</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="fadeModeCombobox"/>
      </item>
      <item>
       <widget class="QSpinBox" name="spinBoxTransition">
@@ -92,57 +172,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pushButtonFadeNow">
-       <property name="toolTip">
-        <string>Trigger the transition to the next track.</string>
-       </property>
-       <property name="text">
-        <string>Fade Now</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonSkipNext">
-       <property name="toolTip">
-        <string>Skip the next track in the Auto DJ queue.</string>
-       </property>
-       <property name="text">
-        <string>Skip Track</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonShuffle">
-       <property name="toolTip">
-        <string>Shuffle the content of the Auto DJ queue.</string>
-       </property>
-       <property name="text">
-        <string>Shuffle</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAddRandom">
-       <property name="toolTip">
-        <string>Adds a random track from track sources (crates) to the Auto DJ queue.
-If no track sources are configured, the track is added from the library instead.</string>
-       </property>
-       <property name="text">
-        <string>Add Random</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="fadeModeCombobox"/>
-     </item>
-     <item>
-       <widget class="QCheckBox" name="repeatPlaylistCheckbox"/>
+      <widget class="QCheckBox" name="repeatPlaylistCheckbox"/>
      </item>
      <item>
       <widget class="QLabel" name="repeatPlaylistLabel">
@@ -183,7 +213,7 @@ If no track sources are configured, the track is added from the library instead.
   </layout>
  </widget>
  <resources>
-  <include location="../res/mixxx.qrc"/>
+  <include location="../../../res/mixxx.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
I have fixed the styles for Shade. This has created some space. 
Unfortunately Mixxx is still unusable in French on small screens. 
This is a blocker for the autodj_intro_outro branch. Even with removing the  "Repeat Playlist" checkbox Mixxx is still unusable. I think we need a solution that dynamically hides some controls.

Did you consider the burger menu solution? We may use it only if "horizontalSpacer" is at minimum. 


![grafik](https://user-images.githubusercontent.com/1777442/64211643-1a713d80-cea7-11e9-9671-d30e3ffcc2a2.png)

