### PR TITLE
Use Cue::kPositionNotDefined for unset cue positions.

### DIFF
--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -9,8 +9,6 @@ constexpr float kSilenceThreshold = 0.001;
 // TODO: Change the above line to:
 //constexpr float kSilenceThreshold = db2ratio(-60.0f);
 
-const double kCueNotSet = -1.0;
-
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(Cue::Type::Intro);
     CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
@@ -118,7 +116,7 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
     // to 0.0 at a later time after analysis because in that case the intro cue
     // would have already been created by this analyzer.
     bool upgradingWithMainCueAtDefault = (mainCue == 0.0 && pIntroCue == nullptr);
-    if (mainCue == kCueNotSet || upgradingWithMainCueAtDefault) {
+    if (mainCue == Cue::kPositionNotDefined || upgradingWithMainCueAtDefault) {
         pTrack->setCuePoint(CuePosition(firstSound));
     // NOTE: the actual default for this ConfigValue is set in DlgPrefDeck.
     } else if (m_pConfig->getValue(ConfigKey("[Controls]", "SetIntroStartAtMainCue"), false)
@@ -130,14 +128,14 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
         pIntroCue = pTrack->createAndAddCue();
         pIntroCue->setType(Cue::Type::Intro);
         pIntroCue->setStartPosition(introStart);
-        pIntroCue->setEndPosition(kCueNotSet);
+        pIntroCue->setEndPosition(Cue::kPositionNotDefined);
     }
 
     CuePointer pOutroCue = pTrack->findCueByType(Cue::Type::Outro);
     if (pOutroCue == nullptr) {
         pOutroCue = pTrack->createAndAddCue();
         pOutroCue->setType(Cue::Type::Outro);
-        pOutroCue->setStartPosition(kCueNotSet);
+        pOutroCue->setStartPosition(Cue::kPositionNotDefined);
         pOutroCue->setEndPosition(lastSound);
     }
 }

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -52,7 +52,7 @@ CueControl::CueControl(QString group,
     m_pClosestBeat = ControlObject::getControl(ConfigKey(group, "beat_closest"));
 
     m_pCuePoint = new ControlObject(ConfigKey(group, "cue_point"));
-    m_pCuePoint->set(-1.0);
+    m_pCuePoint->set(Cue::kPositionNotDefined);
 
     m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
 
@@ -115,7 +115,7 @@ CueControl::CueControl(QString group,
     m_pPlayIndicator = new ControlIndicator(ConfigKey(group, "play_indicator"));
 
     m_pIntroStartPosition = new ControlObject(ConfigKey(group, "intro_start_position"));
-    m_pIntroStartPosition->set(kNoTrigger);
+    m_pIntroStartPosition->set(Cue::kPositionNotDefined);
 
     m_pIntroStartEnabled = new ControlObject(ConfigKey(group, "intro_start_enabled"));
     m_pIntroStartEnabled->setReadOnly();
@@ -136,7 +136,7 @@ CueControl::CueControl(QString group,
             Qt::DirectConnection);
 
     m_pIntroEndPosition = new ControlObject(ConfigKey(group, "intro_end_position"));
-    m_pIntroEndPosition->set(kNoTrigger);
+    m_pIntroEndPosition->set(Cue::kPositionNotDefined);
 
     m_pIntroEndEnabled = new ControlObject(ConfigKey(group, "intro_end_enabled"));
     m_pIntroEndEnabled->setReadOnly();
@@ -157,7 +157,7 @@ CueControl::CueControl(QString group,
             Qt::DirectConnection);
 
     m_pOutroStartPosition = new ControlObject(ConfigKey(group, "outro_start_position"));
-    m_pOutroStartPosition->set(kNoTrigger);
+    m_pOutroStartPosition->set(Cue::kPositionNotDefined);
 
     m_pOutroStartEnabled = new ControlObject(ConfigKey(group, "outro_start_enabled"));
     m_pOutroStartEnabled->setReadOnly();
@@ -178,7 +178,7 @@ CueControl::CueControl(QString group,
             Qt::DirectConnection);
 
     m_pOutroEndPosition = new ControlObject(ConfigKey(group, "outro_end_position"));
-    m_pOutroEndPosition->set(kNoTrigger);
+    m_pOutroEndPosition->set(Cue::kPositionNotDefined);
 
     m_pOutroEndEnabled = new ControlObject(ConfigKey(group, "outro_end_enabled"));
     m_pOutroEndEnabled->setReadOnly();
@@ -308,14 +308,14 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         }
 
         m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
-        m_pCuePoint->set(-1.0);
-        m_pIntroStartPosition->set(-1.0);
+        m_pCuePoint->set(Cue::kPositionNotDefined);
+        m_pIntroStartPosition->set(Cue::kPositionNotDefined);
         m_pIntroStartEnabled->forceSet(0.0);
-        m_pIntroEndPosition->set(-1.0);
+        m_pIntroEndPosition->set(Cue::kPositionNotDefined);
         m_pIntroEndEnabled->forceSet(0.0);
-        m_pOutroStartPosition->set(-1.0);
+        m_pOutroStartPosition->set(Cue::kPositionNotDefined);
         m_pOutroStartEnabled->forceSet(0.0);
-        m_pOutroEndPosition->set(-1.0);
+        m_pOutroEndPosition->set(Cue::kPositionNotDefined);
         m_pOutroEndEnabled->forceSet(0.0);
         m_pLoadedTrack.reset();
     }
@@ -374,7 +374,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
 
     CuePointer pAudibleSound = pNewTrack->findCueByType(Cue::Type::AudibleSound);
-    double firstSound = kNoTrigger;
+    double firstSound = Cue::kPositionNotDefined;
     if (pAudibleSound) {
         firstSound = pAudibleSound->getPosition();
     }
@@ -388,14 +388,14 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         }
         break;
     case SeekOnLoadMode::FirstSound:
-        if (firstSound != kNoTrigger) {
+        if (firstSound != Cue::kPositionNotDefined) {
             seekExact(firstSound);
         } else {
             seekExact(0.0);
         }
         break;
     case SeekOnLoadMode::MainCue:
-        if (mainCuePoint.getPosition() != kNoTrigger) {
+        if (mainCuePoint.getPosition() != Cue::kPositionNotDefined) {
             seekExact(mainCuePoint.getPosition());
         } else {
             seekExact(0.0);
@@ -404,7 +404,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     case SeekOnLoadMode::IntroStart:
         {
             double introStart = m_pIntroStartPosition->get();
-            if (introStart != kNoTrigger) {
+            if (introStart != Cue::kPositionNotDefined) {
                 seekExact(introStart);
             } else {
                 seekExact(0.0);
@@ -470,13 +470,13 @@ void CueControl::loadCuesFromTrack() {
         double endPosition = pIntroCue->getEndPosition();
 
         m_pIntroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::PreviousBeat));
-        m_pIntroStartEnabled->forceSet(startPosition == -1.0 ? 0.0 : 1.0);
+        m_pIntroStartEnabled->forceSet(startPosition == Cue::kPositionNotDefined ? 0.0 : 1.0);
         m_pIntroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::NextBeat));
-        m_pIntroEndEnabled->forceSet(endPosition == -1.0 ? 0.0 : 1.0);
+        m_pIntroEndEnabled->forceSet(endPosition == Cue::kPositionNotDefined ? 0.0 : 1.0);
     } else {
-        m_pIntroStartPosition->set(-1.0);
+        m_pIntroStartPosition->set(Cue::kPositionNotDefined);
         m_pIntroStartEnabled->forceSet(0.0);
-        m_pIntroEndPosition->set(-1.0);
+        m_pIntroEndPosition->set(Cue::kPositionNotDefined);
         m_pIntroEndEnabled->forceSet(0.0);
     }
 
@@ -485,13 +485,13 @@ void CueControl::loadCuesFromTrack() {
         double endPosition = pOutroCue->getEndPosition();
 
         m_pOutroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::PreviousBeat));
-        m_pOutroStartEnabled->forceSet(startPosition == -1.0 ? 0.0 : 1.0);
+        m_pOutroStartEnabled->forceSet(startPosition == Cue::kPositionNotDefined ? 0.0 : 1.0);
         m_pOutroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::NextBeat));
-        m_pOutroEndEnabled->forceSet(endPosition == -1.0 ? 0.0 : 1.0);
+        m_pOutroEndEnabled->forceSet(endPosition == Cue::kPositionNotDefined ? 0.0 : 1.0);
     } else {
-        m_pOutroStartPosition->set(-1.0);
+        m_pOutroStartPosition->set(Cue::kPositionNotDefined);
         m_pOutroStartEnabled->forceSet(0.0);
-        m_pOutroEndPosition->set(-1.0);
+        m_pOutroEndPosition->set(Cue::kPositionNotDefined);
         m_pOutroEndEnabled->forceSet(0.0);
     }
 
@@ -499,7 +499,7 @@ void CueControl::loadCuesFromTrack() {
         double position = pLoadCue->getPosition();
         m_pCuePoint->set(quantizeCuePoint(position, QuantizeMode::ClosestBeat));
     } else {
-        m_pCuePoint->set(-1.0);
+        m_pCuePoint->set(Cue::kPositionNotDefined);
     }
 
     // Detach all hotcues that are no longer present
@@ -531,11 +531,11 @@ void CueControl::reloadCuesFromTrack() {
     SeekOnLoadMode seekOnLoadMode = getSeekOnLoadPreference();
 
     if (seekOnLoadMode == SeekOnLoadMode::MainCue) {
-        if ((trackAt == TrackAt::Cue || wasTrackAtZeroPos) && cue != -1.0) {
+        if ((trackAt == TrackAt::Cue || wasTrackAtZeroPos) && cue != Cue::kPositionNotDefined) {
             seekExact(cue);
         }
     } else if (seekOnLoadMode == SeekOnLoadMode::IntroStart) {
-        if ((wasTrackAtIntroCue || wasTrackAtZeroPos) && intro != -1.0) {
+        if ((wasTrackAtIntroCue || wasTrackAtZeroPos) && intro != Cue::kPositionNotDefined) {
             seekExact(intro);
         }
     }
@@ -843,7 +843,7 @@ void CueControl::cueClear(double v) {
     }
 
     QMutexLocker lock(&m_mutex);
-    m_pCuePoint->set(-1.0);
+    m_pCuePoint->set(Cue::kPositionNotDefined);
     TrackPointer pLoadedTrack = m_pLoadedTrack;
     lock.unlock();
 
@@ -1128,15 +1128,15 @@ void CueControl::introStartSet(double v) {
     double introEnd = m_pIntroEndPosition->get();
     double outroStart = m_pOutroStartPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
-    if (introEnd != -1.0 && position >= introEnd) {
+    if (introEnd != Cue::kPositionNotDefined && position >= introEnd) {
         qWarning() << "Trying to place intro start cue on or after intro end cue.";
         return;
     }
-    if (outroStart != -1.0 && position >= outroStart) {
+    if (outroStart != Cue::kPositionNotDefined && position >= outroStart) {
         qWarning() << "Trying to place intro start cue on or after outro start cue.";
         return;
     }
-    if (outroEnd != -1.0 && position >= outroEnd) {
+    if (outroEnd != Cue::kPositionNotDefined && position >= outroEnd) {
         qWarning() << "Trying to place intro start cue on or after outro end cue.";
         return;
     }
@@ -1151,7 +1151,7 @@ void CueControl::introStartSet(double v) {
             pCue->setType(Cue::Type::Intro);
         }
         pCue->setStartPosition(position);
-        pCue->setLength(introEnd != -1.0 ? introEnd - position : 0.0);
+        pCue->setLength(introEnd != Cue::kPositionNotDefined ? introEnd - position : 0.0);
     }
 }
 
@@ -1167,8 +1167,8 @@ void CueControl::introStartClear(double v) {
 
     if (pLoadedTrack) {
         CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
-        if (introEnd != -1.0) {
-            pCue->setStartPosition(-1.0);
+        if (introEnd != Cue::kPositionNotDefined) {
+            pCue->setStartPosition(Cue::kPositionNotDefined);
             pCue->setLength(introEnd);
         } else if (pCue) {
             pLoadedTrack->removeCue(pCue);
@@ -1182,7 +1182,7 @@ void CueControl::introStartActivate(double v) {
         double introStart = m_pIntroStartPosition->get();
         lock.unlock();
 
-        if (introStart == -1.0) {
+        if (introStart == Cue::kPositionNotDefined) {
             introStartSet(1.0);
         } else {
             seekAbs(introStart);
@@ -1206,15 +1206,15 @@ void CueControl::introEndSet(double v) {
     double introStart = m_pIntroStartPosition->get();
     double outroStart = m_pOutroStartPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
-    if (introStart != -1.0 && position <= introStart) {
+    if (introStart != Cue::kPositionNotDefined && position <= introStart) {
         qWarning() << "Trying to place intro end cue on or before intro start cue.";
         return;
     }
-    if (outroStart != -1.0 && position >= outroStart) {
+    if (outroStart != Cue::kPositionNotDefined && position >= outroStart) {
         qWarning() << "Trying to place intro end cue on or after outro start cue.";
         return;
     }
-    if (outroEnd != -1.0 && position >= outroEnd) {
+    if (outroEnd != Cue::kPositionNotDefined && position >= outroEnd) {
         qWarning() << "Trying to place intro end cue on or after outro end cue.";
         return;
     }
@@ -1228,11 +1228,11 @@ void CueControl::introEndSet(double v) {
             pCue = pLoadedTrack->createAndAddCue();
             pCue->setType(Cue::Type::Intro);
         }
-        if (introStart != -1.0) {
+        if (introStart != Cue::kPositionNotDefined) {
             pCue->setStartPosition(introStart);
             pCue->setLength(position - introStart);
         } else {
-            pCue->setStartPosition(-1.0);
+            pCue->setStartPosition(Cue::kPositionNotDefined);
             pCue->setLength(position);
         }
     }
@@ -1250,7 +1250,7 @@ void CueControl::introEndClear(double v) {
 
     if (pLoadedTrack) {
         CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Intro);
-        if (introStart != -1.0) {
+        if (introStart != Cue::kPositionNotDefined) {
             pCue->setStartPosition(introStart);
             pCue->setLength(0.0);
         } else if (pCue) {
@@ -1265,7 +1265,7 @@ void CueControl::introEndActivate(double v) {
         double introEnd = m_pIntroEndPosition->get();
         lock.unlock();
 
-        if (introEnd == -1.0) {
+        if (introEnd == Cue::kPositionNotDefined) {
             introEndSet(1.0);
         } else {
             seekAbs(introEnd);
@@ -1289,15 +1289,15 @@ void CueControl::outroStartSet(double v) {
     double introStart = m_pIntroStartPosition->get();
     double introEnd = m_pIntroEndPosition->get();
     double outroEnd = m_pOutroEndPosition->get();
-    if (introStart != -1.0 && position <= introStart) {
+    if (introStart != Cue::kPositionNotDefined && position <= introStart) {
         qWarning() << "Trying to place outro start cue on or before intro start cue.";
         return;
     }
-    if (introEnd != -1.0 && position <= introEnd) {
+    if (introEnd != Cue::kPositionNotDefined && position <= introEnd) {
         qWarning() << "Trying to place outro start cue on or before intro end cue.";
         return;
     }
-    if (outroEnd != -1.0 && position >= outroEnd) {
+    if (outroEnd != Cue::kPositionNotDefined && position >= outroEnd) {
         qWarning() << "Trying to place outro start cue on or after outro end cue.";
         return;
     }
@@ -1312,7 +1312,7 @@ void CueControl::outroStartSet(double v) {
             pCue->setType(Cue::Type::Outro);
         }
         pCue->setStartPosition(position);
-        pCue->setLength(outroEnd != -1.0 ? outroEnd - position : 0.0);
+        pCue->setLength(outroEnd != Cue::kPositionNotDefined ? outroEnd - position : 0.0);
     }
 }
 
@@ -1328,8 +1328,8 @@ void CueControl::outroStartClear(double v) {
 
     if (pLoadedTrack) {
         CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
-        if (outroEnd != -1.0) {
-            pCue->setStartPosition(-1.0);
+        if (outroEnd != Cue::kPositionNotDefined) {
+            pCue->setStartPosition(Cue::kPositionNotDefined);
             pCue->setLength(outroEnd);
         } else if (pCue) {
             pLoadedTrack->removeCue(pCue);
@@ -1343,7 +1343,7 @@ void CueControl::outroStartActivate(double v) {
         double outroStart = m_pOutroStartPosition->get();
         lock.unlock();
 
-        if (outroStart == -1.0) {
+        if (outroStart == Cue::kPositionNotDefined) {
             outroStartSet(1.0);
         } else {
             seekAbs(outroStart);
@@ -1367,15 +1367,15 @@ void CueControl::outroEndSet(double v) {
     double introStart = m_pIntroStartPosition->get();
     double introEnd = m_pIntroEndPosition->get();
     double outroStart = m_pOutroStartPosition->get();
-    if (introStart != -1.0 && position <= introStart) {
+    if (introStart != Cue::kPositionNotDefined && position <= introStart) {
         qWarning() << "Trying to place outro end cue on or before intro start cue.";
         return;
     }
-    if (introEnd != -1.0 && position <= introEnd) {
+    if (introEnd != Cue::kPositionNotDefined && position <= introEnd) {
         qWarning() << "Trying to place outro end cue on or before intro end cue.";
         return;
     }
-    if (outroStart != -1.0 && position <= outroStart) {
+    if (outroStart != Cue::kPositionNotDefined && position <= outroStart) {
         qWarning() << "Trying to place outro end cue on or before outro start cue.";
         return;
     }
@@ -1389,11 +1389,11 @@ void CueControl::outroEndSet(double v) {
             pCue = pLoadedTrack->createAndAddCue();
             pCue->setType(Cue::Type::Outro);
         }
-        if (outroStart != -1.0) {
+        if (outroStart != Cue::kPositionNotDefined) {
             pCue->setStartPosition(outroStart);
             pCue->setLength(position - outroStart);
         } else {
-            pCue->setStartPosition(-1.0);
+            pCue->setStartPosition(Cue::kPositionNotDefined);
             pCue->setLength(position);
         }
     }
@@ -1411,7 +1411,7 @@ void CueControl::outroEndClear(double v) {
 
     if (pLoadedTrack) {
         CuePointer pCue = pLoadedTrack->findCueByType(Cue::Type::Outro);
-        if (outroStart != -1.0) {
+        if (outroStart != Cue::kPositionNotDefined) {
             pCue->setStartPosition(outroStart);
             pCue->setLength(0.0);
         } else if (pCue) {
@@ -1426,7 +1426,7 @@ void CueControl::outroEndActivate(double v) {
         double outroEnd = m_pOutroEndPosition->get();
         lock.unlock();
 
-        if (outroEnd == -1.0) {
+        if (outroEnd == Cue::kPositionNotDefined) {
             outroEndSet(1.0);
         } else {
             seekAbs(outroEnd);
@@ -1626,7 +1626,7 @@ double CueControl::quantizeCurrentPosition(QuantizeMode mode) {
 
 double CueControl::quantizeCuePoint(double position, QuantizeMode mode) {
     // Don't quantize unset cues, manual cues or when quantization is disabled.
-    if (position == -1.0 || !m_pQuantizeEnabled->toBool()) {
+    if (position == Cue::kPositionNotDefined || !m_pQuantizeEnabled->toBool()) {
         return position;
     }
 
@@ -1815,10 +1815,10 @@ void HotcueControl::resetCue() {
     // clear pCue first because we have a null check for valid data else where
     // in the code
     m_pCue.reset();
-    setPosition(-1.0);
+    setPosition(Cue::kPositionNotDefined);
 }
 
 void HotcueControl::setPosition(double position) {
     m_hotcuePosition->set(position);
-    m_hotcueEnabled->forceSet(position == -1.0 ? 0.0 : 1.0);
+    m_hotcueEnabled->forceSet(position == Cue::kPositionNotDefined ? 0.0 : 1.0);
 }


### PR DESCRIPTION
Cue::kPositionNotDefined is quite long and used often. 
How about short it too Cue::kNoPos or Cue::kNullPos or similar